### PR TITLE
Add feature 'debug' for installing the Debug plugin

### DIFF
--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -30,6 +30,16 @@ function add_auto_login( $password ) {
 }
 
 /**
+ * Install and activates the Debug plugin on the site.
+ */
+function add_debug_plugin() {
+	$cmd = 'wp plugin install debug --activate';
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}
+
+/**
  * Install and activates Jetpack on the site.
  */
 function add_jetpack() {
@@ -62,13 +72,14 @@ function add_wordpress_beta_tester_plugin() {
 /**
  * Launches a new WordPress instance on the managed server
  * @param  String  $runtime              The PHP runtime versino to run the app on.
- * @param  Array  $features             Array of features to enable
+ * @param  Array  $features              Array of features to enable
  *         boolean ssl                   Should we add SSL for the site?
  *         boolean jetpack               Should we add Jetpack to the site?
  *         boolean jetpack-beta          Should we add Jetpack Beta Tester plugin to the site?
  *         boolean subdir_multisite      Should we enable subdir-based multisite on the site?
  *         boolean subdir_multisite      Should we enable subdomain-based multisite on the site?
  *         boolean wordpress-beta-tester Should we add Jetpack Beta Tester plugin to the site?
+ *         boolean debug                 Should we add the Debug plugin to the site?
  * @return Array|Null                    null or the app data as returned by ServerPilot's API on creation.
  */
 function launch_wordpress( $runtime = 'php5.6', $requested_features ) {
@@ -79,6 +90,7 @@ function launch_wordpress( $runtime = 'php5.6', $requested_features ) {
 		'subdir_multisite' => false,
 		'subdomain_multisite' => false,
 		'wordpress-beta-tester' => false,
+		'debug' => false,
 	];
 	$features = array_merge( $default_features, $requested_features );
 
@@ -112,6 +124,9 @@ function launch_wordpress( $runtime = 'php5.6', $requested_features ) {
 
 		if ( $features['wordpress-beta-tester'] ) {
 			add_wordpress_beta_tester_plugin();
+		}
+		if ( $features['debug'] ) {
+			add_debug_plugin();
 		}
 
 		add_auto_login( $password );


### PR DESCRIPTION
Allows to install the [Debug plugin](https://wordpress.org/plugins/debug).

So, `WP_DEBUG` and `WP_DEBUG_LOG` can be enabled without the need for editing `wp-config.php` by hand