### PR TITLE
Rename $errors to $jurassic_ninja_errors

### DIFF
--- a/lib/error-stuff.php
+++ b/lib/error-stuff.php
@@ -6,7 +6,7 @@ if ( ! defined( '\\ABSPATH' ) ) {
 	exit;
 }
 
-$errors = [];
+$jurassic_ninja_errors = [];
 
 /**
  * Registers a hook to admin_notices
@@ -32,6 +32,7 @@ function admin_noticies() {
 		<ul>
 			<?php
 			foreach ( errors() as $error ) {
+			    error_log( print_r( $error, true ) ) ;
 			?>
 				<li>
 				<?php echo esc_html( $error->get_error_message() ); ?>
@@ -71,8 +72,8 @@ function list_in_words( $list = [] ) {
  * @return [Array] array of WP_Error
  */
 function errors() {
-	global $errors;
-	return $errors;
+	global $jurassic_ninja_errors;
+	return $jurassic_ninja_errors;
 }
 
 /**
@@ -80,7 +81,7 @@ function errors() {
  * @param  WP_Error  $err An error to be shown in the admin notice.
  */
 function push_error( $err ) {
-	global $errors;
-	$errors[] = $err;
+	global $jurassic_ninja_errors;
+	$jurassic_ninja_errors[] = $err;
 }
 

--- a/lib/error-stuff.php
+++ b/lib/error-stuff.php
@@ -32,7 +32,6 @@ function admin_noticies() {
 		<ul>
 			<?php
 			foreach ( errors() as $error ) {
-			    error_log( print_r( $error, true ) ) ;
 			?>
 				<li>
 				<?php echo esc_html( $error->get_error_message() ); ?>


### PR DESCRIPTION
yeah, namespaces have no “namespace globals”. They’re just globals. And
wp-includes/widgets.php already defined a global $errors.