### PR TITLE
Add setting to make launched sites have a site title related to their subdomain

### DIFF
--- a/lib/settings-stuff.php
+++ b/lib/settings-stuff.php
@@ -136,6 +136,13 @@ function add_settings_page() {
 							'placeholder' => 'INTERVAL 2 HOUR',
 							'value' => 'INTERVAL 2 HOUR',
 						),
+						'use_subdomain_based_wordpress_title' => array(
+							'id' => 'use_subdomain_based_wordpress_title',
+							'title' => __( 'Base the site titles on their subdomain', 'jurassic-ninja' ),
+							'text' => __( 'Example: http://ugly-unicorn.domain will be titled "Ugly Unicorn".', 'jurassic-ninja' ),
+							'type' => 'checkbox',
+							'checked' => false,
+						),
 						'add_jetpack_by_default' => array(
 							'id' => 'add_jetpack_by_default',
 							'title' => __( 'Add Jetpack to every launched WordPress', 'jurassic-ninja' ),

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -131,13 +131,19 @@ function launch_wordpress( $runtime = 'php5.6', $requested_features ) {
 	try {
 		$password = generate_random_password();
 		$user = generate_new_user( $password );
+		$subdomain = generate_random_subdomain();
+			// title-case the subdomain
+			// or default to the classic My WordPress Site
+		$site_title = settings( 'use_subdomain_based_wordpress_title', false ) ?
+			ucwords( str_replace( '-', ' ', $subdomain ) ) :
+			'My WordPress Site';
 		$wordpress_options = array(
-			'site_title' => 'My WordPress Site',
+			'site_title' => $site_title,
 			'admin_user' => 'demo',
 			'admin_password' => $password,
 			'admin_email' => settings( 'default_admin_email_address' ),
 		);
-		$domain = generate_random_subdomain() . '.' . settings( 'domain' );
+		$domain = sprintf( '%s.%s', $subdomain, settings( 'domain' ) );
 		// If creating a subdomain based multisite, we need to tell ServerPilot that the app as a wildcard subdomain.
 		$domain_arg = $features['subdomain_multisite'] ? array( $domain, '*.' . $domain ) : array( $domain );
 		$app = create_sp_app( $user->data->name, $user->data->id, $runtime, $domain_arg, $wordpress_options );


### PR DESCRIPTION
Fixes #45.

A site with domain prehistoric-persian.jurassic.ninja will have a WordPress title of "Prehistoric Ninja"