### PR TITLE
Add/woocommerce get parameter

### DIFF
--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -128,12 +128,16 @@ function isCreatePage() {
 if ( isCreatePage() ) {
 	const shortlived = param( 'shortlived' );
 	const jetpack = param( 'jetpack' );
+	const woocommerce = param( 'woocommerce' );
 	const features = {};
 	if ( shortlived !== null ) {
 		features.shortlived = shortlived;
 	}
 	if ( jetpack !== null ) {
 		features.jetpack = jetpack;
+	}
+	if ( woocommerce !== null ) {
+		features.woocommerce = woocommerce;
 	}
 	setTimeout( () => {
 		doIt( jQuery, features );

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -25,6 +25,7 @@ function add_rest_api_endpoints() {
 		$defaults = [
 			'jetpack' => (bool)settings( 'add_jetpack_by_default', true ),
 			'jetpack-beta' => (bool) settings( 'add_jetpack_beta_by_default', false ),
+			'woocommerce' => (bool)settings( 'add_woocommerce_by_default', true ),
 			'shortlife' => false,
 		];
 		$json_params = $request->get_json_params();
@@ -40,6 +41,9 @@ function add_rest_api_endpoints() {
 		] );
 		if ( isset( $json_params['jetpack'] ) ) {
 			$features['jetpack'] = $json_params['jetpack'];
+		}
+		if ( isset( $json_params['woocommerce'] ) ) {
+			$features['woocommerce'] = $json_params['woocommerce'];
 		}
 
 		$data = launch_wordpress( 'php5.6', $features );

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -25,7 +25,7 @@ function add_rest_api_endpoints() {
 		$defaults = [
 			'jetpack' => (bool)settings( 'add_jetpack_by_default', true ),
 			'jetpack-beta' => (bool) settings( 'add_jetpack_beta_by_default', false ),
-			'woocommerce' => (bool)settings( 'add_woocommerce_by_default', true ),
+			'woocommerce' => (bool) settings( 'add_woocommerce_by_default', true ),
 			'shortlife' => false,
 		];
 		$json_params = $request->get_json_params();

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -29,7 +29,7 @@ function add_rest_api_endpoints() {
 			'shortlife' => false,
 		];
 		$json_params = $request->get_json_params();
-		$features = $json_params && is_array( $json_params ) ? $json_params : [];
+
 		if ( ! settings( 'enable_launching', true ) ) {
 			return new \WP_Error( 'site_launching_disabled', __( 'Site launching is disabled right now' ), [
 				'status' => 503,

--- a/lib/settings-stuff.php
+++ b/lib/settings-stuff.php
@@ -164,6 +164,13 @@ function add_settings_page() {
 							'type' => 'checkbox',
 							'checked' => false,
 						),
+						'add_woocommerce_by_default' => array(
+							'id' => 'add_woocommerce_by_default',
+							'title' => __( 'Add WooCommerce to every launched WordPress', 'jurassic-ninja' ),
+							'text' => __( 'Install and activate WooCommerce on launch', 'jurassic-ninja' ),
+							'type' => 'checkbox',
+							'checked' => false,
+						),
 						'purge_sites_when_cron_runs' => array(
 							'id' => 'purge_sites_when_cron_runs',
 							'title' => __( 'Run the cron task that purges sites when they expire  (Hourly)', 'jurassic-ninja' ),


### PR DESCRIPTION
Similar to #60 

Makes the JS code detect the GET parameters `woocommerce` or `nowoocommerce` if present in `/create`.

Also introduces setting `add_woocommerce_by_default` so it can be configured eventually to always launch with Woo installed and active. 

![image](https://user-images.githubusercontent.com/746152/32750982-09446d22-c8a3-11e7-9cd7-ad3d3f42bc03.png)
