### PR TITLE
Add possibility to install jetpack PR branch

### DIFF
--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -20,38 +20,38 @@ const originalProgressText = jQuery( '#progress' ).text();
 
 function doIt( $, features ) {
 	$( function() {
-		$( '#img1').show();
-		$( '#img2').hide();
+		$( '#img1' ).show();
+		$( '#img2' ).hide();
 
 		createSite( features )
 			.then( response => {
-				$('#progress').html( `<a href="${ response.data.url }">The new WP is ready to go, visit it!</a>` );
-				$('#img1').hide();
-				$('#img2').show();
+				$( '#progress' ).html( `<a href="${ response.data.url }">The new WP is ready to go, visit it!</a>` );
+				$( '#img1' ).hide();
+				$( '#img2' ).show();
 			} )
 			.catch( err => {
-				$('#progress').text( `Oh No! There was a problem launching the new WP. (${ err.message }).` );
-				$('#img2').hide();
-				$('#img1').attr( 'src', 'https://i.imgur.com/vdyaxmx.gif');
+				$( '#progress' ).text( `Oh No! There was a problem launching the new WP. (${ err.message }).` );
+				$( '#img2' ).hide();
+				$( '#img1' ).attr( 'src', 'https://i.imgur.com/vdyaxmx.gif' );
 			} );
 	} );
 }
 
 function doItWithFeatures( $, features ) {
 	$( function() {
-		$( '#progress').show();
-		$( '#img1').show();
+		$( '#progress' ).show();
+		$( '#img1' ).show();
 		$( '#img2').hide();
 		launchSiteWithFeatures( features )
 			.then( response => {
-				$('#progress').html( `<a href="${ response.data.url }">The new WP is ready to go, visit it!</a>` );
-				$('#img1').hide();
-				$('#img2').show();
+				$( '#progress' ).html( `<a href="${ response.data.url }">The new WP is ready to go, visit it!</a>` );
+				$( '#img1' ).hide();
+				$( '#img2' ).show();
 			} )
 			.catch( err => {
-				$('#progress').text( `Oh No! There was a problem launching the new WP. (${ err.message }).` );
-				$('#img2').hide();
-				$('#img1').attr( 'src', 'https://i.imgur.com/vdyaxmx.gif');
+				$( '#progress' ).text( `Oh No! There was a problem launching the new WP. (${ err.message }).` );
+				$( '#img2' ).hide();
+				$( '#img1' ).attr( 'src', 'https://i.imgur.com/vdyaxmx.gif' );
 			} );
 	} );
 }
@@ -135,7 +135,7 @@ if ( isCreatePage() ) {
 	const jetpack = param( 'jetpack' );
 	const woocommerce = param( 'woocommerce' );
 	const jetpack_beta = param( 'jetpack-beta' );
-	const branch = param('branch')
+	const branch = param( 'branch' )
 	const features = {};	
 	if ( shortlived !== null ) {
 		features.shortlived = shortlived;
@@ -148,8 +148,7 @@ if ( isCreatePage() ) {
 	}
 	if ( jetpack_beta !== null ) {
 		features[ 'jetpack-beta' ] = jetpack_beta;
-		features.branch = ( branch !== null ? 'stable' : branch );
-
+		features.branch = ( branch !== null ? branch : 'stable' );
 	}
 
 	setTimeout( () => {
@@ -158,9 +157,9 @@ if ( isCreatePage() ) {
 }
 
 if ( isSpecialOpsPage() ) {
-	jQuery( '[data-is-create-button]').click( function () {
-		jQuery( '#img1').show();
-		jQuery( '#img2').hide();
+	jQuery( '[data-is-create-button]' ).click( function () {
+		jQuery( '#img1' ).show();
+		jQuery( '#img2' ).hide();
 		jQuery( '#progress' ).text( originalProgressText );
 		const $this = jQuery( this );
 		const features = collectFeatures();
@@ -173,14 +172,14 @@ if ( isSpecialOpsPage() ) {
 	} )
 }
 
-function param(name) {
+function param( name ) {
 	let params;
 	if ( location.search ) {
-		let params = location.search.split('?')[1].split('&');
+		let params = location.search.split( '?' )[1].split( '&' );
 		// branch option is only valid when jetpack-beta is used.
-		if (name == 'branch' && params.includes( 'jetpack-beta' ) ) {
-			let branch = params.filter(param => param.startsWith('branch'))
-			return branch.length ? branch[0].split('=')[1] : 'master'
+		if ( name == 'branch' && params.includes( 'jetpack-beta' ) ) {
+			let branch = params.filter( param => param.startsWith( 'branch' ) )
+			return branch.length ? branch[0].split( '=' )[1] : 'master'
 		}
 		if ( params.includes( name ) ) {
 			return true;

--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -147,10 +147,9 @@ if ( isCreatePage() ) {
 		features.woocommerce = woocommerce;
 	}
 	if ( jetpack_beta !== null ) {
-		features['jetpack-beta'] = jetpack_beta;
-		if ( branch !== null ) {
-			features.branch = branch;
-		}
+		features[ 'jetpack-beta' ] = jetpack_beta;
+		features.branch = ( branch !== null ? 'stable' : branch );
+
 	}
 
 	setTimeout( () => {

--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -134,7 +134,9 @@ if ( isCreatePage() ) {
 	const shortlived = param( 'shortlived' );
 	const jetpack = param( 'jetpack' );
 	const woocommerce = param( 'woocommerce' );
-	const features = {};
+	const jetpack_beta = param( 'jetpack-beta' );
+	const branch = param('branch')
+	const features = {};	
 	if ( shortlived !== null ) {
 		features.shortlived = shortlived;
 	}
@@ -144,6 +146,13 @@ if ( isCreatePage() ) {
 	if ( woocommerce !== null ) {
 		features.woocommerce = woocommerce;
 	}
+	if ( jetpack_beta !== null ) {
+		features['jetpack-beta'] = jetpack_beta;
+		if ( branch !== null ) {
+			features.branch = branch;
+		}
+	}
+
 	setTimeout( () => {
 		doIt( jQuery, features );
 	}, 1000 );
@@ -169,6 +178,11 @@ function param(name) {
 	let params;
 	if ( location.search ) {
 		let params = location.search.split('?')[1].split('&');
+		// branch option is only valid when jetpack-beta is used.
+		if (name == 'branch' && params.includes( 'jetpack-beta' ) ) {
+			let branch = params.filter(param => param.startsWith('branch'))
+			return branch.length ? branch[0].split('=')[1] : 'master'
+		}
 		if ( params.includes( name ) ) {
 			return true;
 		}

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -47,6 +47,17 @@ function add_rest_api_endpoints() {
 		}
 
 		if ( isset( $json_params['jetpack-beta'] ) ) {
+			$url = get_jetpack_beta_url( $json_params['branch'] );
+			
+			if ( $url === null ) {
+				return new \WP_Error(
+					'failed_to_launch_site',
+					esc_html__( 'Invalid branch name: ' . $json_params['branch'] ),
+					[
+						'status' => 500,
+					]
+				);
+			}
 			$features['jetpack-beta'] = $json_params['jetpack-beta'];
 			$features['branch'] = $json_params['branch'];
 		}
@@ -204,4 +215,18 @@ function add_endpoint( $namespace, $path, $callback, $register_rest_route_option
 	add_action( 'rest_api_init', function () use ( $namespace, $path, $options ) {
 		register_rest_route( $namespace, $path, $options );
 	} );
+}
+
+function get_jetpack_beta_url( $branch_name ) {
+	$branch_name = str_replace( '/', '_', $branch_name );
+	$manifest_url = "https://betadownload.jetpack.me/jetpack-branches.json";
+	$manifest = json_decode( wp_remote_retrieve_body( wp_remote_get( $manifest_url ) ) );
+
+	if ( ( 'rc' === $branch_name || 'master' === $branch_name ) && isset( $manifest->{$branch_name}->download_url ) ) {
+		return $manifest->{$branch_name}->download_url;
+	}
+
+	if ( isset( $manifest->pr->{$branch_name}->download_url ) ) {
+		return $manifest->pr->{$branch_name}->download_url;
+	}
 }

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -46,6 +46,11 @@ function add_rest_api_endpoints() {
 			$features['woocommerce'] = $json_params['woocommerce'];
 		}
 
+		if ( isset( $json_params['jetpack-beta'] ) ) {
+			$features['jetpack-beta'] = $json_params['jetpack-beta'];
+			$features['branch'] = $json_params['branch'];
+		}
+
 		$data = launch_wordpress( 'php7.0', $features );
 		$url = 'http://' . figure_out_main_domain( $data->domains );
 
@@ -63,7 +68,7 @@ function add_rest_api_endpoints() {
 				'status' => 503,
 			] );
 		}
-
+		
 		$data = launch_wordpress( $features['runtime'], $features );
 
 		$url = 'http://' . figure_out_main_domain( $data->domains );

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -79,17 +79,7 @@ function add_jetpack_beta_plugin() {
  * Activates jetpack branch in Beta plugin
  */
 function activate_jetpack_branch( $branch_name ) {
-	switch ($branch_name) {
-    case 'master':
-			$section = 'master';
-			break;
-    case 'stable':
-			$section = 'stable';
-			break;
-    default:
-			$section = 'pr';
-}	
-	$cmd = "wp jetpack-beta branch activate $section $branch_name";
+	$cmd = "wp jetpack-beta branch activate $branch_name";
 	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
 		return "$s && $cmd";
 	} );
@@ -577,14 +567,8 @@ function random_string( $length = 32 ) {
  */
 function run_command_on_behalf( $user, $password, $cmd ) {
 	$domain = settings( 'domain' );
-	$cmd_with_done = $cmd . '&& echo "done"';
-	$run = "SSHPASS=$password sshpass -e ssh -oStrictHostKeyChecking=no $user@$domain '$cmd_with_done'";
-	$output = shell_exec( $run );
-	debug( 'OUTPUT: %s', $output );	
-	if ( $output != 'done' ) {
-		throw new Error( 'The API responded in a weird way' );
-	}
-	return true;
+	$run = "SSHPASS=$password sshpass -e ssh -oStrictHostKeyChecking=no $user@$domain '$cmd'";
+	return shell_exec( $run );
 }
 
 /**

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -143,7 +143,6 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 
 	try {
 		$password = generate_random_password();
-		$user = generate_new_user( $password );
 		$subdomain = '';
 		$collision_attempts = 10;
 		do {
@@ -169,6 +168,12 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		$domain_arg = $features['subdomain_multisite'] ? array( $domain, '*.' . $domain ) : array( $domain );
 
 		debug( 'Launching %s with features: %s', $domain, implode( ', ' , array_keys( array_filter( $features ) ) ) );
+
+		debug( 'Creating sysuser for %s', $domain );
+
+		$user = generate_new_user( $password );
+
+		debug( 'Creating app for %s under sysuser %s', $domain, $user->data->name );
 
 		$app = create_sp_app( $user->data->name, $user->data->id, $runtime, $domain_arg, $wordpress_options );
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -76,6 +76,26 @@ function add_jetpack_beta_plugin() {
 }
 
 /**
+ * Activates jetpack branch in Beta plugin
+ */
+function activate_jetpack_branch( $branch_name ) {
+	switch ($branch_name) {
+    case 'master':
+			$section = 'master';
+			break;
+    case 'stable':
+			$section = 'stable';
+			break;
+    default:
+			$section = 'pr';
+}	
+	$cmd = "wp jetpack-beta branch activate $section $branch_name";
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}
+
+/**
  * Installs and activates WooCommerce on the site.
  */
 function add_woocommerce_plugin() {
@@ -170,8 +190,8 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		debug( 'Launching %s with features: %s', $domain, implode( ', ' , array_keys( array_filter( $features ) ) ) );
 
 		debug( 'Creating sysuser for %s', $domain );
-
-		$user = generate_new_user( $password );
+		
+		$user = generate_new_user( $password );		
 
 		debug( 'Creating app for %s under sysuser %s', $domain, $user->data->name );
 
@@ -189,6 +209,11 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		if ( $features['jetpack-beta'] ) {
 			debug( '%s: Adding Jetpack Beta Tester Plugin', $domain );
 			add_jetpack_beta_plugin();
+		}
+
+		if ( $features['branch'] ) {
+			debug( '%s: Activating Jetpack %s branch in Beta plugin', $domain, $features["branch"]);
+			activate_jetpack_branch($features['branch']);
 		}
 
 		if ( $features['wordpress-beta-tester'] ) {
@@ -552,8 +577,14 @@ function random_string( $length = 32 ) {
  */
 function run_command_on_behalf( $user, $password, $cmd ) {
 	$domain = settings( 'domain' );
-	$run = "SSHPASS=$password sshpass -e ssh -oStrictHostKeyChecking=no $user@$domain '$cmd'";
-	return shell_exec( $run );
+	$cmd_with_done = $cmd . '&& echo "done"';
+	$run = "SSHPASS=$password sshpass -e ssh -oStrictHostKeyChecking=no $user@$domain '$cmd_with_done'";
+	$output = shell_exec( $run );
+	debug( 'OUTPUT: %s', $output );	
+	if ( $output != 'done' ) {
+		throw new Error( 'The API responded in a weird way' );
+	}
+	return true;
 }
 
 /**

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -183,8 +183,8 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		debug( 'Launching %s with features: %s', $domain, implode( ', ' , array_keys( array_filter( $features ) ) ) );
 
 		debug( 'Creating sysuser for %s', $domain );
-		
-		$user = generate_new_user( $password );		
+
+		$user = generate_new_user( $password );
 
 		debug( 'Creating app for %s under sysuser %s', $domain, $user->data->name );
 
@@ -580,7 +580,7 @@ function run_command_on_behalf( $user, $password, $cmd ) {
 	if ( 0 !== $return_value ) {
 		debug( 'Commands run finished with code %s and output: %s',
 			$return_value,
-			implode( "\n", $output )
+			implode( " -> ", $output )
 		);
 		return new \WP_Error(
 			'commands_did_not_run_successfully',

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -144,6 +144,7 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		'wordpress-beta-tester' => false,
 		'wp-log-viewer' => false,
 		'shortlife' => false,
+		'branch' => false,
 	];
 	$features = array_merge( $default_features, $requested_features );
 


### PR DESCRIPTION
Add possibility to install any jetpack branch during site creation. This would give a possibility to migrate jetpack related wp-e2e-tests to jurassic.ninja completely.

implemented: url options: `create/?jetpack-beta&branch=try/branch-name`

This PR relies on already merged functionalities in jetpack-beta plugin(https://github.com/Automattic/jetpack-beta/pull/42)

cc @oskosk 

  