### PR TITLE
Settings: avoid exception being thrown when options are not there yet

### DIFF
--- a/lib/settings-stuff.php
+++ b/lib/settings-stuff.php
@@ -17,10 +17,6 @@ define( 'SETTINGS_KEY', 'jurassic-ninja-settings' );
 function settings( $key = null, $default = null ) {
 	$options = get_option( SETTINGS_KEY );
 
-	if ( ! ( $options ) ) {
-		throw new \Exception( 'Error Finding config variable', 1 );
-	}
-
 	// Create the array needed by ServerPilot() here so I don't have to copy/paste this around
 	if ( 'serverpilot' === $key ) {
 		return [


### PR DESCRIPTION
Fixes #73.