### PR TITLE
Add wp-debug-log GET parameter support and setting for enabling it by default

### DIFF
--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -136,6 +136,7 @@ if ( isCreatePage() ) {
 	const jetpack = param( 'jetpack' );
 	const woocommerce = param( 'woocommerce' );
 	const jetpack_beta = param( 'jetpack-beta' );
+	const wp_debug_log = param( 'wp-debug-log' )
 	const branch = param( 'branch' )
 	const features = {};
 	if ( shortlived !== null ) {
@@ -146,6 +147,9 @@ if ( isCreatePage() ) {
 	}
 	if ( woocommerce !== null ) {
 		features.woocommerce = woocommerce;
+	}
+	if ( wp_debug_log !== null ) {
+		features[ 'wp-debug-log' ] = wp_debug_log;
 	}
 	if ( jetpack_beta !== null ) {
 		features[ 'jetpack-beta' ] = jetpack_beta;

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -26,6 +26,7 @@ function add_rest_api_endpoints() {
 			'jetpack' => (bool)settings( 'add_jetpack_by_default', true ),
 			'jetpack-beta' => (bool) settings( 'add_jetpack_beta_by_default', false ),
 			'woocommerce' => (bool) settings( 'add_woocommerce_by_default', false ),
+			'wp-debug-log' => (bool) settings( 'set_wp_debug_log_by_default', false ),
 			'shortlife' => false,
 		];
 		$json_params = $request->get_json_params();
@@ -45,10 +46,13 @@ function add_rest_api_endpoints() {
 		if ( isset( $json_params['woocommerce'] ) ) {
 			$features['woocommerce'] = $json_params['woocommerce'];
 		}
+		if ( isset( $json_params['wp-debug-log'] ) ) {
+			$features['wp-debug-log'] = $json_params['wp-debug-log'];
+		}
 
 		if ( isset( $json_params['jetpack-beta'] ) ) {
 			$url = get_jetpack_beta_url( $json_params['branch'] );
-			
+
 			if ( $url === null ) {
 				return new \WP_Error(
 					'failed_to_launch_site',
@@ -88,7 +92,7 @@ function add_rest_api_endpoints() {
 				'status' => 503,
 			] );
 		}
-		
+
 		$data = launch_wordpress( $features['runtime'], $features );
 		if ( null === $data ) {
 			return new \WP_Error(

--- a/lib/settings-stuff.php
+++ b/lib/settings-stuff.php
@@ -174,6 +174,13 @@ function add_settings_page() {
 							'type' => 'checkbox',
 							'checked' => false,
 						),
+						'set_wp_debug_log_by_default' => array(
+							'id' => 'set_wp_debug_log_by_default',
+							'title' => __( 'Set WP_DEBUG and WP_DEBUG_LOG to true on every launched WordPress', 'jurassic-ninja' ),
+							'text' => __( 'Enabling debugging log on launch', 'jurassic-ninja' ),
+							'type' => 'checkbox',
+							'checked' => false,
+						),
 						'purge_sites_when_cron_runs' => array(
 							'id' => 'purge_sites_when_cron_runs',
 							'title' => __( 'Run the cron task that purges sites when they expire  (Hourly)', 'jurassic-ninja' ),


### PR DESCRIPTION
... So we can have `/create?wp-debug-log`