### PR TITLE
Add ability to launch sites with SSL

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 2.0
+ * Version: 2.1
  * Author: Osk
  **/
 

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -28,6 +28,7 @@ function add_rest_api_endpoints() {
 			'woocommerce' => (bool) settings( 'add_woocommerce_by_default', false ),
 			'wp-debug-log' => (bool) settings( 'set_wp_debug_log_by_default', false ),
 			'shortlife' => false,
+			'ssl' => (bool) settings( 'ssl_use_custom_certificate', false ),
 		];
 		$json_params = $request->get_json_params();
 
@@ -90,7 +91,9 @@ function add_rest_api_endpoints() {
 				]
 			);
 		}
-		$url = 'http://' . figure_out_main_domain( $data->domains );
+		// See note in launch_wordpress() about why we can't launch subdomain_multisite with ssl.
+		$schema = $features['ssl'] && ! $features['subdomain_multisite'] ? 'https' : 'http';
+		$url = "$schema://" . figure_out_main_domain( $data->domains );
 
 		$output = [
 			'url' => $url,
@@ -100,7 +103,11 @@ function add_rest_api_endpoints() {
 
 	add_post_endpoint( 'specialops/create', function ( $request ) {
 		$json_params = $request->get_json_params();
+		$defaults = [
+			'ssl' => (bool) settings( 'ssl_use_custom_certificate', false ),
+		];
 		$features = $json_params && is_array( $json_params ) ? $json_params : [];
+		$features = array_merge( $defaults, $features );
 		if ( ! settings( 'enable_launching', true ) ) {
 			return new \WP_Error( 'site_launching_disabled', __( 'Site launching is disabled right now' ), [
 				'status' => 503,
@@ -117,7 +124,9 @@ function add_rest_api_endpoints() {
 				]
 			);
 		}
-		$url = 'http://' . figure_out_main_domain( $data->domains );
+		// See note in launch_wordpress() about why we can't launch subdomain_multisite with ssl.
+		$schema = $features['ssl'] && ! $features['subdomain_multisite'] ? 'https' : 'http';
+		$url = "$schema://" . figure_out_main_domain( $data->domains );
 
 		$output = [
 			'url' => $url,

--- a/lib/serverpilot-stuff.php
+++ b/lib/serverpilot-stuff.php
@@ -81,7 +81,7 @@ function delete_sp_sysuser( $id ) {
 }
 
 /**
- * Tries to enable SSL on a ServerPilot app
+ * Tries to enable auto SSL on a ServerPilot app
  * This is currently not working so well due to the amount
  * of instances created by ServerPilot and the throttling mechanism
  * enforced by Let's Encrypt.
@@ -89,7 +89,7 @@ function delete_sp_sysuser( $id ) {
  * @param  string $app_id The ServerPilot id for the app
  * @return [type]         [description]
  */
-function enable_ssl( $app_id ) {
+function enable_auto_ssl( $app_id ) {
 	try {
 		$data = sp()->ssl_auto( $app_id );
 		wait_for_serverpilot_action( $data->actionid );

--- a/lib/settings-stuff.php
+++ b/lib/settings-stuff.php
@@ -232,6 +232,36 @@ function add_settings_page() {
 						),
 					),
 				),
+				'ssl' => array(
+					'title' => __( 'SSL Configuration', 'jurassic-ninja' ),
+					'text' => '<p>' . __( 'Pase a wildcard SSL certificate and the private key used to generate it.' ) . '</p>',
+					'fields' => array(
+						'ssl_use_custom_certificate' => array(
+							'id' => 'ssl_use_custom_certificate',
+							'title' => __( 'Use custom SSL certificate', 'jurassic-ninja' ),
+							'type' => 'checkbox',
+							'checked' => false,
+						),
+						'ssl_certificate' => array(
+							'id' => 'ssl_certificate',
+							'title' => __( 'SSL certificate', 'jurassic-ninja' ),
+							'text' => __( 'Paste the text here.' ),
+							'type' => 'textarea',
+						),
+						'ssl_private_key' => array(
+							'id' => 'ssl_private_key',
+							'title' => __( 'The private key used to create the certificate', 'jurassic-ninja' ),
+							'text' => __( 'Paste the text here.' ),
+							'type' => 'textarea',
+						),
+						'ssl_ca_certificates' => array(
+							'id' => 'ssl_ca_certificates',
+							'title' => __( 'CA certificates', 'jurassic-ninja' ),
+							'text' => __( 'Paste the text here.' ),
+							'type' => 'textarea',
+						),
+					),
+				),
 			),
 		),
 	] );

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -125,7 +125,7 @@ function add_wp_log_viewer_plugin() {
  * @param  String  $runtime              The PHP runtime versino to run the app on.
  * @param  Array   $features             Array of features to enable
  *         boolean config-constants      Should we add the Config Constants plugin to the site?
- *         boolean ssl                   Should we add SSL for the site?
+ *         boolean auto_ssl              Should we add Let's Encrypt-based SSL for the site?
  *         boolean gutenberg             Should we add Gutenberg to the site?
  *         boolean jetpack               Should we add Jetpack to the site?
  *         boolean jetpack-beta          Should we add Jetpack Beta Tester plugin to the site?
@@ -148,7 +148,7 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 	 * @param array $features array of default values for feature flags
 	*/
 	$default_features = apply_filters( 'jurassic_ninja_features_default_values', [
-		'ssl' => false,
+		'auto_ssl' => false,
 		'config-constants' => false,
 		'gutenberg' => false,
 		'jetpack' => false,
@@ -208,8 +208,8 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		}
 		log_new_site( $app->data, $features['shortlife'] );
 
-		if ( $features['ssl'] ) {
-			enable_ssl( $app->data->id );
+		if ( $features['auto_ssl'] ) {
+			enable_auto_ssl( $app->data->id );
 		}
 		if ( $features['jetpack'] ) {
 			debug( '%s: Adding Jetpack', $domain );


### PR DESCRIPTION
* Adds checkbox for enabling or disabling the launching with a custom certificate.
* Adds textareas for pasting Private Key and SSL certificate
* Renames feature `ssl` to `auto_ssl`.
* Blocks custom ssl feature for subdomain based multisite as regular wildcard certificates are not useful beyond the first subdomain.
* Blocks custom ssl if feature `auto_ssl` is also being requested. This should probably throw instead of just logging a debug message.
* **Bumps version to 2.1**


**Current issues**

1. [x] ~There's an error by which everytime a site with SSL is launched, everything breaks. 
   nginx reports `failed (SSL: error:0906D066:PEM routines:PEM_read_bio:bad end line)`. When I get to see the cert file, it's stripped from the `----- END CERTIFICATE -----` line. Don't know at which level this error is happening~. The certificate was somehow formatted badly. Bad copy/paste or something. Still, should check for validity of it, because the ugliest symptom is that regular sites broke too as nginx was refusing to start or so.
2. [x] ~SSL certification addition via API is taking too long. The SP action for adding the cert is taking too long, and the action ends up failing with error event though I can enable forced redirection from http to https afterwards~. Solved by not waiting for the `ssl_add` action. It just works anyways.
   * Maybe try passing the CA certificate too ? Added this feature but it wasn't the problem. Originally I thought that it would take time for SP to go and fetch the certificatis by itself but it's not the case.
3. [x]  ~The redirect done by the companion plugin is not working properly~. Fixed by https://github.com/oskosk/companion/pull/9.