### PR TITLE
Add ability to launch with wp-rollback installed

### DIFF
--- a/features/wp-rollback.php
+++ b/features/wp-rollback.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace jn;
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'wp-rollback' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['wp-rollback'] ) {
+			debug( '%s: Adding Wp Rollback', $domain );
+			add_wp_rollback_plugin();
+		}
+	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_feature_defaults', function( $defaults ) {
+		return array_merge( $defaults, [
+			'wp-rollback' => false,
+		] );
+	} );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['wp-rollback'] ) ) {
+			$features['wp-rollback'] = $json_params['wp-rollback'];
+		}
+		return $features;
+	}, 10, 2 );
+} );
+
+/**
+ * Installs and activates Wp Rollback on the site.
+ */
+function add_wp_rollback_plugin() {
+	$cmd = 'wp plugin install wp-rollback --activate' ;
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -68,6 +68,7 @@ function require_feature_files() {
 		'/features/wordpress-beta-tester.php',
 		'/features/wp-debug-log.php',
 		'/features/wp-log-viewer.php',
+		'/features/wp-rollback.php',
 	];
 
 	$available_features =  apply_filters( 'jurassic_ninja_available_features', $available_features );


### PR DESCRIPTION
[WP Rollback](https://wordpress.org/plugins/wp-rollback/) adds the ability to install an old version of any plugin if
it's still on the Plugin Directory.