### PR TITLE
Mitigate issues with PHP-FPM not gracefully restarting when sent USR1 signal on ServerPilot

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 3.3
+ * Version: 3.3.1
  * Author: Osk
  **/
 

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -88,7 +88,7 @@ function add_rest_api_endpoints() {
 			] );
 		}
 
-		$data = launch_wordpress( $features['runtime'], $features );
+		$data = launch_wordpress( $features['php_version'], $features );
 
 		if ( null === $data ) {
 			return new \WP_Error(

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -48,7 +48,7 @@ function add_rest_api_endpoints() {
 			return $features;
 		}
 
-		$data = launch_wordpress( 'php7.0', $features );
+		$data = launch_wordpress( 'default', $features );
 		if ( null === $data ) {
 			return new \WP_Error(
 				'failed_to_launch_site',

--- a/lib/serverpilot-stuff.php
+++ b/lib/serverpilot-stuff.php
@@ -16,11 +16,11 @@ if ( ! defined( '\\ABSPATH' ) ) {
 $serverpilot_instance = null;
 
 add_action( 'jurassic_ninja_init', function() {
-	add_action( 'jurassic_ninja_create_app', function( &$app, $user, $runtime, $domain, $wordpress_options, $features ) {
+	add_action( 'jurassic_ninja_create_app', function( &$app, $user, $php_version, $domain, $wordpress_options, $features ) {
 		// If creating a subdomain based multisite, we need to tell ServerPilot that the app as a wildcard subdomain.
 		$domain_arg = isset( $features['subdomain_multisite'] ) && $features['subdomain_multisite'] ? array( $domain, '*.' . $domain ) : array( $domain );
 
-		$app = create_sp_app( $user->data->name, $user->data->id, $runtime, $domain_arg, $wordpress_options );
+		$app = create_sp_app( $user->data->name, $user->data->id, $php_version, $domain_arg, $wordpress_options );
 	}, 10, 6 );
 	add_action( 'jurassic_ninja_create_sysuser', function( &$return, $username, $password ) {
 		try {
@@ -86,16 +86,16 @@ function sp() {
 
 /**
  * Creates a PHP app using ServerPilot's API
- * @param  String $name      The nickname of the App
- * @param  String $sysuserid The System User that will "own" this App
- * @param  String $runtime   The PHP runtime for an App. Choose from php5.4, php5.5, php5.6, php7.0, or php7.1.
- * @param  Array  $domains   An array of domains that will be used in the webserver's configuration
- * @param  Array  $wordpress An array containing the following keys: site_title , admin_user , admin_password , and admin_email
- * @return Object            An object with the new app data.
+ * @param  String $name          The nickname of the App
+ * @param  String $sysuserid     The System User that will "own" this App
+ * @param  String $php_version   The PHP version for an App. Choose from php5.4, php5.5, php5.6, php7.0, or php7.1.
+ * @param  Array  $domains       An array of domains that will be used in the webserver's configuration
+ * @param  Array  $wordpress     An array containing the following keys: site_title , admin_user , admin_password , and admin_email
+ * @return Object                An object with the new app data.
  */
-function create_sp_app( $name, $sysuserid, $runtime, $domains, $wordpress ) {
+function create_sp_app( $name, $sysuserid, $php_version, $domains, $wordpress ) {
 	try {
-		$app = sp()->app_create( $name, $sysuserid, $runtime, $domains, $wordpress );
+		$app = sp()->app_create( $name, $sysuserid, $php_version, $domains, $wordpress );
 		wait_for_serverpilot_action( $app->actionid );
 		return $app;
 	} catch ( \ServerPilotException $e ) {

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -98,7 +98,7 @@ function require_feature_files() {
  *         boolean wp-log-viewer         Should we add WP Log Viewer plugin to the site?
  * @return Array|Null                    null or the app data as returned by ServerPilot's API on creation.
  */
-function launch_wordpress( $php_version = 'php7.0', $requested_features = [] ) {
+function launch_wordpress( $php_version = 'default', $requested_features = [] ) {
 	$default_features = [
 		'shortlife' => false,
 	];

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -82,7 +82,7 @@ function require_feature_files() {
 
 /**
  * Launches a new WordPress instance on the managed server
- * @param  String  $runtime              The PHP runtime versino to run the app on.
+ * @param  String  $php_version          The PHP version to run the app on.
  * @param  Array   $features             Array of features to enable
  *         boolean config-constants      Should we add the Config Constants plugin to the site?
  *         boolean auto_ssl              Should we add Let's Encrypt-based SSL for the site?
@@ -98,7 +98,7 @@ function require_feature_files() {
  *         boolean wp-log-viewer         Should we add WP Log Viewer plugin to the site?
  * @return Array|Null                    null or the app data as returned by ServerPilot's API on creation.
  */
-function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
+function launch_wordpress( $php_version = 'php7.0', $requested_features = [] ) {
 	$default_features = [
 		'shortlife' => false,
 	];
@@ -173,7 +173,7 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		 *
 		 *     @type object $app                 Passed by reference. This object should contain the resulting data after creating a PHP app.
 		 *     @type object $user                An object that is the result of creating a new system user under which the app will run.
-		 *     @type string $runtime             The PHP version we're going to use.
+		 *     @type string $php_version         The PHP version we're going to use.
 		 *     @type string $domain              The domain under which this app will be running.
 		 *     @type array  $wordpress_options {
 		 *           An array of properties used for setting up the WordPress site for the first time.
@@ -186,7 +186,7 @@ function launch_wordpress( $runtime = 'php7.0', $requested_features = [] ) {
 		 * }
 		 *
 		 */
-		do_action_ref_array( 'jurassic_ninja_create_app', [ &$app, $user, $runtime, $domain, $wordpress_options, $features ] );
+		do_action_ref_array( 'jurassic_ninja_create_app', [ &$app, $user, $php_version, $domain, $wordpress_options, $features ] );
 
 		if ( is_wp_error( $app ) ) {
 			throw new \Exception( 'Error creating app: ' . $app->get_error_message() );


### PR DESCRIPTION
#### Changes intrdouced in this PR:

* Renames the `runtime` parameter everywhere to be named `php_version` instead
* Randomizes the PHP version used for creating shortlived sites.

### Rationale

PHP-FPM receives USR1 after creating a new site or deleting one. This does not help keep the existing PHP FPM pools alive 
and every other usage of a site running a PHP version that gets restarted results in 503 errors.